### PR TITLE
feat: fix the dependency on ecr creation

### DIFF
--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -22,6 +22,7 @@ resource "aws_ecr_repository" "sd_consumer_ecr" {
   image_tag_mutability = "MUTABLE"
 }
 resource "aws_ecr_repository_policy" "ecrpolicy" {
+  count = var.create_ecr ? 1 : 0
   depends_on = [
     aws_ecr_repository.sd_consumer_ecr
   ]


### PR DESCRIPTION
## Context

If create_ecr is set to false, the ecr policy creation also should be false

## Objective

This PR fixes the issue of using depends_on for resource policy creation failing when create_ecr is false
The depends_on feature seems to be not working when using the resource count

## References


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
