### PR TITLE
Update main.tf

### DIFF
--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -31,11 +31,12 @@ locals {
 module "build_artifact_bucket" {
   source = "terraform-aws-modules/s3-bucket/aws"
   bucket = var.bucket_name
-  acl    = "private"
   block_public_acls = true
   block_public_policy = true
   ignore_public_acls = true
   restrict_public_buckets = true
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
 
   versioning = {
     enabled = false


### PR DESCRIPTION
## Context

S3 has introduced S3 Object Ownership setting, Bucket owner enforced, that disables access control lists (ACLs)
which causes bucket creation to fail

## Objective

This PR adds `object_ownership` to `ObjectWriter`.
'ObjectWriter': The uploading account will own the object if the object is uploaded with the bucket-owner-full-control canned ACL 

## References

https://aws.amazon.com/about-aws/whats-new/2021/11/amazon-s3-object-ownership-simplify-access-management-data-s3


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
