### PR TITLE
feat: update lambda runtime and handler

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -32,11 +32,11 @@ module "lambda_function" {
 
   function_name          = var.consumer_fn_name
   description            = "Screwdriver AWS Integration Consumer"
-  handler                = "aws-consumer-service"
-  runtime                = "go1.x"
+  handler                = "bootstrap"
+  runtime                = "provided.al2023"
   create_package         = true
   create_role            = false
-  source_path            = "./lambda/aws-consumer-service"
+  source_path            = "./lambda/bootstrap"
   vpc_subnet_ids         = var.private_subnets
   vpc_security_group_ids = [var.security_group_id]
   memory_size            = "128"

--- a/setup.sh
+++ b/setup.sh
@@ -162,13 +162,13 @@ get_tf_output() {
 
 get_consumer_svc_pkg() {
     printf "===Getting screwdriver consumer-service package===\n"
-    if [ ! -f "lambda/aws-consumer-service" ];then
+    if [ ! -f "lambda/bootstrap" ];then
         mkdir -p lambda
         cd lambda
         wget -q -O - https://api.github.com/repos/screwdriver-cd/aws-consumer-service/releases/latest \
         | egrep -o "/screwdriver-cd/aws-consumer-service/releases/download/v[0-9.]*/aws-consumer-service_linux_amd64" \
-        | wget --base=http://github.com/ -i - -O aws-consumer-service
-        chmod +x ./aws-consumer-service
+        | wget --base=http://github.com/ -i - -O bootstrap
+        chmod +x ./bootstrap
         cd ..
     fi
 }


### PR DESCRIPTION
## Context

We must update the lambda runtime and handler as the `go1.x` is deprecated.

## Objective

This PR updates the lambda runtime to `provided.al2023` and handler to `bootstrap`

## References

https://github.com/screwdriver-cd/aws-consumer-service/pull/13
https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
